### PR TITLE
Add Signing SDK link to docs

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -19,7 +19,7 @@
 
 # -- Project information -----------------------------------------------------
 
-project = u'Sawtooth-sdk-ios'
+project = u'Sawtooth SDK Swift'
 copyright = u'2019, Bitwise IO, Inc.'
 author = u'Bitwise IO, Inc.'
 
@@ -117,7 +117,7 @@ html_show_sphinx = False
 # -- Options for HTMLHelp output ---------------------------------------------
 
 # Output file base name for HTML help builder.
-htmlhelp_basename = 'Sawtooth-sdk-iosdoc'
+htmlhelp_basename = 'sawtooth-sdk-swiftdoc'
 
 
 # -- Options for LaTeX output ------------------------------------------------
@@ -144,7 +144,7 @@ latex_elements = {
 # (source start file, target name, title,
 #  author, documentclass [howto, manual, or own class]).
 latex_documents = [
-    (master_doc, 'Sawtooth-sdk-ios.tex', u'Sawtooth-sdk-ios Documentation',
+    (master_doc, 'sawtooth-sdk-swift.tex', u'sawtooth-sdk-swift Documentation',
      u'Bitwise IO, Inc.', 'manual'),
 ]
 
@@ -154,7 +154,7 @@ latex_documents = [
 # One entry per manual page. List of tuples
 # (source start file, name, description, authors, manual section).
 man_pages = [
-    (master_doc, 'sawtooth-sdk-ios', u'Sawtooth-sdk-ios Documentation',
+    (master_doc, 'sawtooth-sdk-swift', u'sawtooth-sdk-swift Documentation',
      [author], 1)
 ]
 
@@ -165,8 +165,8 @@ man_pages = [
 # (source start file, target name, title, author,
 #  dir menu entry, description, category)
 texinfo_documents = [
-    (master_doc, 'Sawtooth-sdk-ios', u'Sawtooth-sdk-ios Documentation',
-     author, 'Sawtooth-sdk-ios', 'One line description of project.',
+    (master_doc, 'sawtooth-sdk-swift', u'sawtooth-sdk-swift Documentation',
+     author, 'sawtooth-sdk-swift', 'One line description of project.',
      'Miscellaneous'),
 ]
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -5,5 +5,5 @@ Table of Contents
    :maxdepth: 2
 
    overview.rst
-   using_ios_sdk.rst
+   using_swift_sdk.rst
    sdk_api_ref.rst

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -6,3 +6,4 @@ Table of Contents
 
    overview.rst
    using_ios_sdk.rst
+   sdk_api_ref.rst

--- a/docs/source/sdk_api_ref.rst
+++ b/docs/source/sdk_api_ref.rst
@@ -1,0 +1,12 @@
+SDK API Reference
+=================
+
+
+.. toctree::
+   :maxdepth: 2
+
+- `Signing
+  <jazzy_docs/index.html>`__
+
+.. Licensed under Creative Commons Attribution 4.0 International License
+.. https://creativecommons.org/licenses/by/4.0/

--- a/docs/source/using_swift_sdk.rst
+++ b/docs/source/using_swift_sdk.rst
@@ -5,7 +5,7 @@ Client: Building and Submitting Transactions
 The process of encoding information to be submitted to a distributed ledger is
 generally non-trivial. A series of cryptographic safeguards are used to
 confirm identity and data validity. Hyperledger Sawtooth is no different, but
-the iOS SDK does provide client functionality that abstracts away
+the Swift SDK does provide client functionality that abstracts away
 most of these details, and greatly simplifies the process of making changes to
 the blockchain.
 


### PR DESCRIPTION
To test, build docs using instructions in `ci/build-docs`, open `docs/_build/index.html` in your browser, navigate to the SDK API Reference section. Clicking the Signing link should bring you to the Swift Signing SDK docs.

I also tacked on a commit that removes a few references to the "iOS SDK". This was renamed a while ago but there are still some holdover references to the old name.

Signed-off-by: Darian Plumb <dplumb@bitwise.io>