### PR TITLE
Fix Swift SDK doc: Titles, intro text, iOS->Swift

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -19,7 +19,7 @@
 
 # -- Project information -----------------------------------------------------
 
-project = u'Sawtooth SDK Swift'
+project = u'Sawtooth Swift SDK'
 copyright = u'2019, Bitwise IO, Inc.'
 author = u'Bitwise IO, Inc.'
 
@@ -144,7 +144,7 @@ latex_elements = {
 # (source start file, target name, title,
 #  author, documentclass [howto, manual, or own class]).
 latex_documents = [
-    (master_doc, 'sawtooth-sdk-swift.tex', u'sawtooth-sdk-swift Documentation',
+    (master_doc, 'sawtooth-sdk-swift.tex', u'Sawtooth Swift SDK Documentation',
      u'Bitwise IO, Inc.', 'manual'),
 ]
 
@@ -154,7 +154,7 @@ latex_documents = [
 # One entry per manual page. List of tuples
 # (source start file, name, description, authors, manual section).
 man_pages = [
-    (master_doc, 'sawtooth-sdk-swift', u'sawtooth-sdk-swift Documentation',
+    (master_doc, 'sawtooth-sdk-swift', u'Sawtooth Swift SDK Documentation',
      [author], 1)
 ]
 
@@ -165,8 +165,8 @@ man_pages = [
 # (source start file, target name, title, author,
 #  dir menu entry, description, category)
 texinfo_documents = [
-    (master_doc, 'sawtooth-sdk-swift', u'sawtooth-sdk-swift Documentation',
-     author, 'sawtooth-sdk-swift', 'One line description of project.',
+    (master_doc, 'sawtooth-sdk-swift', u'Sawtooth Swift SDK Documentation',
+     author, 'sawtooth-sdk-swift', 'Learn how to write a Sawtooth client with the Swift SDK.',
      'Miscellaneous'),
 ]
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -1,5 +1,9 @@
-Table of Contents
-============================================
+Sawtooth Swift SDK Documentation
+================================
+
+This guide describes how to use the Sawtooth Swift SDK
+to develop a client application for
+`Hyperledger Sawtooth <https://sawtooth.hyperledger.org/docs/core/releases/latest/>`.
 
 .. toctree::
    :maxdepth: 2

--- a/docs/source/overview.rst
+++ b/docs/source/overview.rst
@@ -1,11 +1,11 @@
 Overview
 ========
 
-This tutorial shows how to use the Sawtooth iOS SDK to develop a
-client. The client is responsible for creating and signing transactions, combining
-those transactions into batches, and submitting them to the validator. The
-client can post batches through the REST API or connect directly to the
-validator via `ZeroMQ <http://zeromq.org>`_.
+This tutorial shows how to use the Sawtooth Swift SDK to develop a
+client application. The client is responsible for creating and signing
+transactions, combining those transactions into batches, and submitting them to
+the validator. The client can post batches through the REST API or connect
+directly to the validator via `ZeroMQ <http://zeromq.org>`_.
 
 .. note::
 

--- a/docs/source/sdk_api_ref.rst
+++ b/docs/source/sdk_api_ref.rst
@@ -1,5 +1,5 @@
-SDK API Reference
-=================
+Swift SDK API Reference
+=======================
 
 
 .. toctree::

--- a/docs/source/using_swift_sdk.rst
+++ b/docs/source/using_swift_sdk.rst
@@ -5,9 +5,8 @@ Client: Building and Submitting Transactions
 The process of encoding information to be submitted to a distributed ledger is
 generally non-trivial. A series of cryptographic safeguards are used to
 confirm identity and data validity. Hyperledger Sawtooth is no different, but
-the Swift SDK does provide client functionality that abstracts away
-most of these details, and greatly simplifies the process of making changes to
-the blockchain.
+the Swift SDK provides client functionality that handles most of these details
+and greatly simplifies the process of making changes to the blockchain.
 
 
 Creating a Private Key and Signer


### PR DESCRIPTION
- Change the doc title to be consistent with other Sawtooth SDK docs

- Add "Swift" to the SDK API Reference (again, for consistency)

- Add an intro sentence to the first page (for context)

- Reword the client topic's intro to be consistent with recent changes
  to the Sawtooth core docs

- Change the one remaining "iOS" to Swift

Signed-off-by: Anne Chenette <chenette@bitwise.io>