### PR TITLE
Add travis-ci yml file for swift builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,65 @@
+language: swift
+osx_image: xcode11
+jobs:
+  include:
+  - stage: Daily Build
+    if: type = cron
+    script:
+        - pip3 install sphinx sphinxcontrib-httpdomain sphinxcontrib-openapi sphinx_rtd_theme
+        - brew install sourcekitten
+        - gem install jazzy
+        - mkdir -p docs/build/html docs/build/tar
+        - cd docs && sphinx-build -b html source build/html && cd ..
+        - swift build
+        - sourcekitten doc --spm-module SawtoothSigning > tmp.json
+        - jazzy --clean --sourcekitten-sourcefile tmp.json -o docs/build/html/jazzy_docs
+        - rm tmp.json
+        - tar -cpvzf docs/build/tar/sawtooth-sdk-swift-docs-nightly.tar.gz docs/build/html
+    deploy:
+        - provider: s3
+          name: sawtooth-sdk-swift daily build
+          access_key_id: "$ACCESS_KEY_ID"
+          secret_access_key: "$SECRET_ACCESS_KEY"
+          bucket: "sawtooth-sdk-swift-artifacts"
+          local_dir: docs/build/tar
+          skip_cleanup: true
+          acl: public_read
+
+  - stage: Release Build
+    if: tag IS present
+    script:
+        - pip3 install sphinx sphinxcontrib-httpdomain sphinxcontrib-openapi sphinx_rtd_theme
+        - brew install sourcekitten
+        - gem install jazzy
+        - mkdir -p docs/build/html docs/build/tar
+        - cd docs && sphinx-build -b html source build/html && cd ..
+        - swift build
+        - sourcekitten doc --spm-module SawtoothSigning > tmp.json
+        - jazzy --clean --sourcekitten-sourcefile tmp.json -o docs/build/html/jazzy_docs
+        - rm tmp.json
+        - tar -cpvzf docs/build/tar/sawtooth-sdk-swift-docs-$TRAVIS_TAG.tar.gz docs/build/html
+    deploy:
+        - provider: s3
+          name: sawtooth-sdk-swift release build
+          access_key_id: "$ACCESS_KEY_ID"
+          secret_access_key: "$SECRET_ACCESS_KEY"
+          bucket: "sawtooth-sdk-swift-artifacts"
+          local_dir: docs/build/tar
+          skip_cleanup: true
+          acl: public_read
+          on:
+            all_branches: true
+
+  - stage: Default Build
+    if: tag IS blank AND NOT type = cron
+    script:
+        - pip3 install sphinx sphinxcontrib-httpdomain sphinxcontrib-openapi sphinx_rtd_theme
+        - brew install sourcekitten
+        - gem install jazzy
+        - mkdir -p docs/build/html docs/build/tar
+        - cd docs && sphinx-build -b html source build/html && cd ..
+        - swift build
+        - sourcekitten doc --spm-module SawtoothSigning > tmp.json
+        - jazzy --clean --sourcekitten-sourcefile tmp.json -o docs/build/html/jazzy_docs
+        - rm tmp.json
+        - tar -cpvzf docs/build/tar/sawtooth-sdk-swift-docs.tar.gz docs/build/html


### PR DESCRIPTION
This .travis.yml has 3 stages, The first stage is for builds scheduled
by cron, this job uploads a nightly artifact to an s3 bucket. The next
stage triggers when the repo is tagged and this uploads an artifact
named after the tag to s3, and the third stage of the build triggers on
branch updates and pull requests, and does not archive any artifacts.

Signed-off-by: Richard Berg <rberg@bitwise.io>