### PR TITLE
Move inactive maintainers to emeritus status

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,10 +1,17 @@
+**Active maintainers**
+
 | Name | GitHub |
 | --- | --- |
 | Andi Gunderson | agunde406 |
+| Shannyn Telander | shannynalayna |
+| Shawn Amundson | vaporos |
+
+**Emeritus maintainers**
+
+| Name | GitHub |
+| --- | --- |
 | Dan Middleton | dcmiddle |
 | Darian Plumb | dplumb94 |
 | Eloá França Verona | eloaverona |
 | James Mitchell | jsmitchell |
 | Peter Schwarz | peterschwarz |
-| Shannyn Telander | shannynalayna |
-| Shawn Amundson | vaporos |


### PR DESCRIPTION
The TOC approved a requirement that maintainers
that have not been active in over three to six
months be move to emeritus status.

These maintainers have not been active in over
one year.

hyperledger/toc#32

Signed-off-by: Ry Jones <ry@linux.com>