### PR TITLE
Retire Darian and Eloá from maintainers and codeowners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-*       @agunde406 @dcmiddle @dplumb94 @eloaverona @jsmitchell @peterschwarz @shannynalayna @vaporos
+*       @agunde406 @dcmiddle @jsmitchell @peterschwarz @shannynalayna @vaporos

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -2,9 +2,13 @@
 | --- | --- |
 | Andi Gunderson | agunde406 |
 | Dan Middleton | dcmiddle |
-| Darian Plumb | dplumb94 |
-| Eloá França Verona | eloaverona |
 | James Mitchell | jsmitchell |
 | Peter Schwarz | peterschwarz |
 | Shannyn Telander | shannynalayna |
 | Shawn Amundson | vaporos |
+
+### Retired Maintainers
+| Name | GitHub |
+| --- | --- |
+| Darian Plumb | dplumb94 |
+| Eloá França Verona | eloaverona |


### PR DESCRIPTION
They have previously indicated they wished to be retired.